### PR TITLE
Add support for systems with only Python3

### DIFF
--- a/samples/build_utils/CMakeLists.txt
+++ b/samples/build_utils/CMakeLists.txt
@@ -90,8 +90,8 @@ macro(FindOpenCLHeaders TARGET)
     set(CMAKE_EXTRA_INCLUDE_FILES)
   endif()
   if (NOT (OPENCL_INC_FOUND AND CL_KERNEL_SUB_GROUP_INFO_SIZE))
-    RequirePythonInterp()
     set(OPENCL_INC_PATH "${CMAKE_BINARY_DIR}")
+    RequirePythonInterp()
 
     add_custom_target(cl_headers ALL
                       DEPENDS "${OPENCL_INC_PATH}/CL/cl.h"
@@ -209,6 +209,7 @@ endmacro()
 
 macro(GetIGAHeaders TARGET)
   set(IGA_INC_PATH "${CMAKE_BINARY_DIR}")
+  RequirePythonInterp()
 
   add_custom_target(iga_headers ALL
                     DEPENDS ${IGA_INC_PATH}/IGA/iga.h

--- a/samples/build_utils/CMakeLists.txt
+++ b/samples/build_utils/CMakeLists.txt
@@ -2,6 +2,15 @@ macro(SetRequiredCMakeVersion)
   set(REQUIRED_CMAKE_VERSION 2.8)
 endmacro()
 
+macro(RequirePythonInterp)
+  if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    find_package(PythonInterp REQUIRED)
+  else()
+    find_package(Python COMPONENTS Interpreter REQUIRED)
+    set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+  endif()
+endmacro()
+
 macro(SetCompilerFlags)
 endmacro()
 
@@ -81,6 +90,7 @@ macro(FindOpenCLHeaders TARGET)
     set(CMAKE_EXTRA_INCLUDE_FILES)
   endif()
   if (NOT (OPENCL_INC_FOUND AND CL_KERNEL_SUB_GROUP_INFO_SIZE))
+    RequirePythonInterp()
     set(OPENCL_INC_PATH "${CMAKE_BINARY_DIR}")
 
     add_custom_target(cl_headers ALL
@@ -92,7 +102,7 @@ macro(FindOpenCLHeaders TARGET)
                               "${OPENCL_INC_PATH}/CL/cl_gl.h"
                               "${OPENCL_INC_PATH}/CL/cl_version.h"
                               "${OPENCL_INC_PATH}/CL/cl_platform.h"
-                      COMMAND python "${PROJECT_SOURCE_DIR}/../build_utils/get_cl_headers.py" "${OPENCL_INC_PATH}" "${CMAKE_BINARY_DIR}")
+                      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/../build_utils/get_cl_headers.py" "${OPENCL_INC_PATH}" "${CMAKE_BINARY_DIR}")
 
     target_include_directories(${TARGET}
       PUBLIC "${OPENCL_INC_PATH}")
@@ -105,13 +115,14 @@ endmacro()
 
 macro(GetOpenCLTracingHeaders TARGET)
   set(OPENCL_TRACING_INC_PATH "${CMAKE_BINARY_DIR}")
+  RequirePythonInterp()
 
   add_custom_target(cl_tracing_headers ALL
                     DEPENDS ${OPENCL_TRACING_INC_PATH}/CL/tracing_api.h
                             ${OPENCL_TRACING_INC_PATH}/CL/tracing_types.h)
   add_custom_command(OUTPUT ${OPENCL_TRACING_INC_PATH}/CL/tracing_api.h
                             ${OPENCL_TRACING_INC_PATH}/CL/tracing_types.h
-                    COMMAND python "${PROJECT_SOURCE_DIR}/../build_utils/get_cl_tracing_headers.py" ${OPENCL_TRACING_INC_PATH} ${CMAKE_BINARY_DIR})
+                    COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/../build_utils/get_cl_tracing_headers.py" ${OPENCL_TRACING_INC_PATH} ${CMAKE_BINARY_DIR})
 
   target_include_directories(${TARGET}
     PUBLIC "${OPENCL_TRACING_INC_PATH}")
@@ -121,6 +132,7 @@ endmacro()
 
 macro(GetITT TARGET)
   set(ITT_INC_PATH "${CMAKE_BINARY_DIR}")
+  RequirePythonInterp()
 
   add_custom_target(itt_headers ALL
                     DEPENDS ${ITT_INC_PATH}/ITT/disable_warnings.h
@@ -137,7 +149,7 @@ macro(GetITT TARGET)
                             ${ITT_INC_PATH}/ITT/ittnotify_types.h
                             ${ITT_INC_PATH}/ITT/ittnotify.h
                             ${ITT_INC_PATH}/ITT/legacy/ittnotify.h
-                    COMMAND python "${PROJECT_SOURCE_DIR}/../build_utils/get_itt.py" ${ITT_INC_PATH} ${CMAKE_BINARY_DIR})
+                    COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/../build_utils/get_itt.py" ${ITT_INC_PATH} ${CMAKE_BINARY_DIR})
   
   target_include_directories(${TARGET}
     PUBLIC "${ITT_INC_PATH}")
@@ -213,7 +225,7 @@ macro(GetIGAHeaders TARGET)
                             ${IGA_INC_PATH}/IGA/iga_bxml_enums.hpp
                             ${IGA_INC_PATH}/IGA/kv.h
                             ${IGA_INC_PATH}/IGA/kv.hpp
-                    COMMAND python "${PROJECT_SOURCE_DIR}/../build_utils/get_iga_headers.py" ${IGA_INC_PATH} ${CMAKE_BINARY_DIR})
+                    COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/../build_utils/get_iga_headers.py" ${IGA_INC_PATH} ${CMAKE_BINARY_DIR})
 
   target_include_directories(${TARGET}
     PUBLIC "${IGA_INC_PATH}")
@@ -223,13 +235,14 @@ endmacro()
 
 macro(GetIGCHeaders TARGET)
   set(IGC_INC_PATH "${CMAKE_BINARY_DIR}")
+  RequirePythonInterp()
 
   add_custom_target(igc_headers ALL
                     DEPENDS ${IGC_INC_PATH}/IGC/program_debug_data.h
                             ${IGC_INC_PATH}/IGC/patch_list.h)
   add_custom_command(OUTPUT ${IGC_INC_PATH}/IGC/program_debug_data.h
                             ${IGC_INC_PATH}/IGC/patch_list.h
-                    COMMAND python "${PROJECT_SOURCE_DIR}/../build_utils/get_igc_headers.py" ${IGC_INC_PATH} ${CMAKE_BINARY_DIR})
+                    COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/../build_utils/get_igc_headers.py" ${IGC_INC_PATH} ${CMAKE_BINARY_DIR})
 
   target_include_directories(${TARGET}
     PUBLIC "${IGC_INC_PATH}")
@@ -303,13 +316,14 @@ endmacro()
 
 macro(GetMDHeaders TARGET)
   set(MD_INC_PATH "${CMAKE_BINARY_DIR}")
+  RequirePythonInterp()
 
   add_custom_target(md_headers ALL
                     DEPENDS ${MD_INC_PATH}/MD/metrics_discovery_api.h
                             ${MD_INC_PATH}/MD/metrics_discovery_internal_api.h)
   add_custom_command(OUTPUT ${MD_INC_PATH}/MD/metrics_discovery_api.h
                             ${MD_INC_PATH}/MD/metrics_discovery_internal_api.h
-                    COMMAND python "${PROJECT_SOURCE_DIR}/../build_utils/get_md_headers.py" ${MD_INC_PATH} ${CMAKE_BINARY_DIR})
+                    COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/../build_utils/get_md_headers.py" ${MD_INC_PATH} ${CMAKE_BINARY_DIR})
 
   target_include_directories(${TARGET}
     PUBLIC "${MD_INC_PATH}")
@@ -333,6 +347,7 @@ macro(FindGTPinLibrary TARGET)
     if(UNIX)
       message(WARNING "Graphics Technology Pin (GT Pin) library path was not defined - it will be downloaded automatically on build")
       set(GTPIN_LIB_PATH "${CMAKE_BINARY_DIR}")
+      RequirePythonInterp()
 
       add_custom_target(gtpin_libs ALL
                         DEPENDS ${GTPIN_LIB_PATH}/GTPIN/libgcc_s.so.1
@@ -347,7 +362,7 @@ macro(FindGTPinLibrary TARGET)
                                 ${GTPIN_LIB_PATH}/GTPIN/libgtpin_core.so
                                 ${GTPIN_LIB_PATH}/GTPIN/libiga_wrapper.so
                                 ${GTPIN_LIB_PATH}/GTPIN/libstdc++.so.6
-                        COMMAND python "${PROJECT_SOURCE_DIR}/../build_utils/get_gtpin_libs.py" ${GTPIN_LIB_PATH} ${CMAKE_BINARY_DIR})
+                        COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/../build_utils/get_gtpin_libs.py" ${GTPIN_LIB_PATH} ${CMAKE_BINARY_DIR})
 
       target_link_libraries(${TARGET}
         "${GTPIN_LIB_PATH}/GTPIN/libgtpin.so")
@@ -369,6 +384,7 @@ macro(GetGTPinHeaders TARGET)
     if(UNIX)
       message(WARNING "Graphics Technology Pin (GT Pin) include path was not defined - it will be downloaded automatically on build")
       set(GTPIN_INC_PATH "${CMAKE_BINARY_DIR}")
+      RequirePythonInterp()
 
       add_custom_target(gtpin_headers ALL
                         DEPENDS ${GTPIN_INC_PATH}/GTPIN/callbacks.h
@@ -403,7 +419,7 @@ macro(GetGTPinHeaders TARGET)
                                 ${GTPIN_INC_PATH}/GTPIN/ged/intel64/ged_enum_types.h
                                 ${GTPIN_INC_PATH}/GTPIN/ged/intel64/ged.h
                                 ${GTPIN_INC_PATH}/GTPIN/ged/intel64/ged_ins_field.h
-                        COMMAND python "${PROJECT_SOURCE_DIR}/../build_utils/get_gtpin_headers.py" ${GTPIN_INC_PATH} ${CMAKE_BINARY_DIR})
+                        COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/../build_utils/get_gtpin_headers.py" ${GTPIN_INC_PATH} ${CMAKE_BINARY_DIR})
 
       target_include_directories(${TARGET}
         PUBLIC "${GTPIN_INC_PATH}/GTPIN"
@@ -452,6 +468,7 @@ macro(FindL0Headers TARGET)
 endmacro()
 
 macro(FindL0HeadersPath TARGET L0_GEN_SCRIPT)
+  RequirePythonInterp()
   find_path(L0_INC_PATH
     NAMES level_zero)
   if (NOT L0_INC_PATH)
@@ -466,7 +483,7 @@ macro(FindL0HeadersPath TARGET L0_GEN_SCRIPT)
   add_custom_target(ze_gen_headers ALL
                     DEPENDS ${L0_GEN_INC_PATH}/tracing.gen)
   add_custom_command(OUTPUT ${L0_GEN_INC_PATH}/tracing.gen
-                     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH="${PROJECT_SOURCE_DIR}/../utils" python ${L0_GEN_SCRIPT} ${L0_GEN_INC_PATH} "${L0_INC_PATH}/level_zero")                     
+                     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH="${PROJECT_SOURCE_DIR}/../utils" "${PYTHON_EXECUTABLE}" ${L0_GEN_SCRIPT} ${L0_GEN_INC_PATH} "${L0_INC_PATH}/level_zero")
   target_include_directories(${TARGET}
     PUBLIC "${L0_GEN_INC_PATH}")
   add_dependencies(${TARGET}


### PR DESCRIPTION
On Ubuntu 20.04 and later, it is possible to have only Python 3 installed. For 20.10, it is the default. In such configurations, there is no `python` binary (unless `python-is-python3` package is installed). This causes a mildly cryptic error when building samples, like:

```
Scanning dependencies of target ze_gen_headers
[ 50%] Generating tracing.gen
No such file or directory
```

In this PR, a built-in CMake mechanics to discover a Python interpreter is employed.

The `find_package(PythonInterp REQUIRED)` syntax is supported, albeit deprecated, in CMake after 3.12. If desired, the conditions in lines 6-11 can be replaced by a single line.

On a related note, the README says ["Python (version 2.8 and above)"](https://github.com/intel/pti-gpu/blame/master/README.md#L74), which is a bit confusing, since [there is no Python 2.8](https://www.python.org/dev/peps/pep-0404/). I'm not sure whether it meant to say 2.7, 2.7.8, or that no release from the 2.x branch is supported.