### PR TITLE
Fix the bug with string passed to putenv function on Windows in utils/utils.h

### DIFF
--- a/utils/utils.h
+++ b/utils/utils.h
@@ -121,7 +121,7 @@ inline void SetEnv(const char* name, const char* value) {
   int status = 0;
 #if defined(_WIN32)
   std::string str = std::string(name) + "=" + value;
-  status = _putenv(str);
+  status = _putenv(str.c_str());
 #else
   status = setenv(name, value, 1);
 #endif


### PR DESCRIPTION
Compilation of Level Zero traces on Windows fails now with following error:
[ 28%] Building CXX object CMakeFiles/zet_tracer.dir/C_/tools/pti-gpu/loader/init.cc.obj
init.cc
C:\tools\pti-gpu\tools\ZE_TRA~1\..\..\utils\utils.h(124): error C2664: 'int _putenv(const char *)': cannot convert argument 1 from 'std::string' to 'const char *'

Need to call c_str() to convert string to char *