### PR TITLE
prof_options.h: add the pid and rank at the position of last "." in f…

### DIFF
--- a/tools/oneprof/prof_options.h
+++ b/tools/oneprof/prof_options.h
@@ -67,7 +67,7 @@ class ProfOptions {
 
     std::stringstream result;
 
-    size_t pos = log_file_.find_first_of('.');
+    size_t pos = log_file_.find_last_of('.');
     if (pos == std::string::npos) {
       result << log_file_;
     } else {


### PR DESCRIPTION
…ilename

the current method of first "." in filename will crash when we give a filename with path, for example: -o ./prof.log or -o /your.path/prof.log