### PR TITLE
Fix unified_tracer.h and add info in README.md so onetrace can be built successfully for Windows

### DIFF
--- a/tools/onetrace/README.md
+++ b/tools/onetrace/README.md
@@ -189,6 +189,10 @@ cd build
 cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=<opencl_icd_lib_path> ..
 nmake
 ```
+Please note that <opencl_icd_lib_path> is the path where you can find in Windows' "Registry Editor" (Search "Registry Editor" with the "magnifying glass" icon) and look under HKEY_LOCAL_MACHINE -> SOFTWARE -> Khronos -> OpenCL -> Vendors and you should see something like this: C:\Program Files (x86)\Intel\oneAPI\compiler\latest\windows\lib\x64\intelocl64.dll, this is your <opencl_icd_lib_path>
+You also need to download and install git, and set up the proxy in the command prompt:
+git config --global http.proxy http://[username]:[password]%40[your proxy]
+
 Use this command line to run the tool:
 ```sh
 onetrace.exe [options] <target_application>

--- a/tools/onetrace/unified_tracer.h
+++ b/tools/onetrace/unified_tracer.h
@@ -6,6 +6,7 @@
 
 #ifndef PTI_TOOLS_ONETRACE_UNIFIED_TRACER_H_
 #define PTI_TOOLS_ONETRACE_UNIFIED_TRACER_H_
+#define NOMINMAX
 
 #include <chrono>
 #include <cstdint>


### PR DESCRIPTION
onetrace cannot be built due to an error in unified_tracer.h, and the lacking of information on how to build the tool for Windows makes the building process difficult. Fixed unified_tracer.h and added more necessary information in README.md to make the built process smoother.