### PR TITLE
Fix Windows build - define NOMINMAX

### DIFF
--- a/utils/utils.h
+++ b/utils/utils.h
@@ -8,6 +8,7 @@
 #define PTI_UTILS_UTILS_H_
 
 #if defined(_WIN32)
+#define NOMINMAX
 #include <windows.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
- prevents min/max macro conflict with std::min/max