### PR TITLE
Support std::experimental::filesystem

### DIFF
--- a/tools/unitrace/CMakeLists.txt
+++ b/tools/unitrace/CMakeLists.txt
@@ -127,6 +127,16 @@ target_include_directories(unitrace_tool PRIVATE "${L0_INC_PATH}")
 # Loader
 
 add_executable(unitrace "${PROJECT_SOURCE_DIR}/src/unitrace.cc")
+
+# Find whether the standard library in use has std::filesystem or
+# std::experimental::filesystem, so that the code can include, call,
+# and link accordingly.
+find_package(Filesystem REQUIRED COMPONENTS Final Experimental)
+target_link_libraries(unitrace std::filesystem)
+target_compile_definitions(unitrace PRIVATE
+    CXX_FILESYSTEM_IS_EXPERIMENTAL=${CXX_FILESYSTEM_IS_EXPERIMENTAL}
+    CXX_FILESYSTEM_NAMESPACE=${CXX_FILESYSTEM_NAMESPACE})
+
 set(_use_mpi 1)
 
 if (BUILD_WITH_MPI)

--- a/tools/unitrace/cmake/FindFilesystem.cmake
+++ b/tools/unitrace/cmake/FindFilesystem.cmake
@@ -1,0 +1,247 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+
+FindFilesystem
+##############
+
+This module supports the C++17 standard library's filesystem utilities. Use the
+:imp-target:`std::filesystem` imported target to
+
+Options
+*******
+
+The ``COMPONENTS`` argument to this module supports the following values:
+
+.. find-component:: Experimental
+    :name: fs.Experimental
+
+    Allows the module to find the "experimental" Filesystem TS version of the
+    Filesystem library. This is the library that should be used with the
+    ``std::experimental::filesystem`` namespace.
+
+.. find-component:: Final
+    :name: fs.Final
+
+    Finds the final C++17 standard version of the filesystem library.
+
+If no components are provided, behaves as if the
+:find-component:`fs.Final` component was specified.
+
+If both :find-component:`fs.Experimental` and :find-component:`fs.Final` are
+provided, first looks for ``Final``, and falls back to ``Experimental`` in case
+of failure. If ``Final`` is found, :imp-target:`std::filesystem` and all
+:ref:`variables <fs.variables>` will refer to the ``Final`` version.
+
+
+Imported Targets
+****************
+
+.. imp-target:: std::filesystem
+
+    The ``std::filesystem`` imported target is defined when any requested
+    version of the C++ filesystem library has been found, whether it is
+    *Experimental* or *Final*.
+
+    If no version of the filesystem library is available, this target will not
+    be defined.
+
+    .. note::
+        This target has ``cxx_std_17`` as an ``INTERFACE``
+        :ref:`compile language standard feature <req-lang-standards>`. Linking
+        to this target will automatically enable C++17 if no later standard
+        version is already required on the linking target.
+
+
+.. _fs.variables:
+
+Variables
+*********
+
+.. variable:: CXX_FILESYSTEM_IS_EXPERIMENTAL
+
+    Set to ``1`` when the :find-component:`fs.Experimental` version of C++
+    filesystem library was found, otherwise ``0``.
+
+.. variable:: CXX_FILESYSTEM_HAVE_FS
+
+    Set to ``TRUE`` when a filesystem header was found.
+
+.. variable:: CXX_FILESYSTEM_HEADER
+
+    Set to either ``filesystem`` or ``experimental/filesystem`` depending on
+    whether :find-component:`fs.Final` or :find-component:`fs.Experimental` was
+    found.
+
+.. variable:: CXX_FILESYSTEM_NAMESPACE
+
+    Set to either ``std::filesystem`` or ``std::experimental::filesystem``
+    depending on whether :find-component:`fs.Final` or
+    :find-component:`fs.Experimental` was found.
+
+
+Examples
+********
+
+Using `find_package(Filesystem)` with no component arguments:
+
+.. code-block:: cmake
+
+    find_package(Filesystem REQUIRED)
+
+    add_executable(my-program main.cpp)
+    target_link_libraries(my-program PRIVATE std::filesystem)
+
+
+#]=======================================================================]
+
+
+if(TARGET std::filesystem)
+    # This module has already been processed. Don't do it again.
+    return()
+endif()
+
+cmake_minimum_required(VERSION 3.10)
+
+include(CMakePushCheckState)
+include(CheckIncludeFileCXX)
+
+# If we're not cross-compiling, try to run test executables.
+# Otherwise, assume that compile + link is a sufficient check.
+if(CMAKE_CROSSCOMPILING)
+    include(CheckCXXSourceCompiles)
+    macro(_cmcm_check_cxx_source code var)
+        check_cxx_source_compiles("${code}" ${var})
+    endmacro()
+else()
+    include(CheckCXXSourceRuns)
+    macro(_cmcm_check_cxx_source code var)
+        check_cxx_source_runs("${code}" ${var})
+    endmacro()
+endif()
+
+cmake_push_check_state()
+
+set(CMAKE_REQUIRED_QUIET ${Filesystem_FIND_QUIETLY})
+
+# All of our tests required C++17 or later
+set(CMAKE_CXX_STANDARD 17)
+
+# Normalize and check the component list we were given
+set(want_components ${Filesystem_FIND_COMPONENTS})
+if(Filesystem_FIND_COMPONENTS STREQUAL "")
+    set(want_components Final)
+endif()
+
+# Warn on any unrecognized components
+set(extra_components ${want_components})
+list(REMOVE_ITEM extra_components Final Experimental)
+foreach(component IN LISTS extra_components)
+    message(WARNING "Extraneous find_package component for Filesystem: ${component}")
+endforeach()
+
+# Detect which of Experimental and Final we should look for
+set(find_experimental TRUE)
+set(find_final TRUE)
+if(NOT "Final" IN_LIST want_components)
+    set(find_final FALSE)
+endif()
+if(NOT "Experimental" IN_LIST want_components)
+    set(find_experimental FALSE)
+endif()
+
+if(find_final)
+    check_include_file_cxx("filesystem" _CXX_FILESYSTEM_HAVE_HEADER)
+    mark_as_advanced(_CXX_FILESYSTEM_HAVE_HEADER)
+    if(_CXX_FILESYSTEM_HAVE_HEADER)
+        # We found the non-experimental header. Don't bother looking for the
+        # experimental one.
+        set(find_experimental FALSE)
+    endif()
+else()
+    set(_CXX_FILESYSTEM_HAVE_HEADER FALSE)
+endif()
+
+if(find_experimental)
+    check_include_file_cxx("experimental/filesystem" _CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+    mark_as_advanced(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+else()
+    set(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER FALSE)
+endif()
+
+if(_CXX_FILESYSTEM_HAVE_HEADER)
+    set(_have_fs TRUE)
+    set(_fs_header filesystem)
+    set(_fs_namespace std::filesystem)
+    set(_is_experimental 0)
+elseif(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+    set(_have_fs TRUE)
+    set(_fs_header experimental/filesystem)
+    set(_fs_namespace std::experimental::filesystem)
+    set(_is_experimental 1)
+else()
+    set(_have_fs FALSE)
+endif()
+
+set(CXX_FILESYSTEM_HAVE_FS ${_have_fs} CACHE BOOL "TRUE if we have the C++ filesystem headers")
+set(CXX_FILESYSTEM_HEADER ${_fs_header} CACHE STRING "The header that should be included to obtain the filesystem APIs")
+set(CXX_FILESYSTEM_NAMESPACE ${_fs_namespace} CACHE STRING "The C++ namespace that contains the filesystem APIs")
+set(CXX_FILESYSTEM_IS_EXPERIMENTAL ${_is_experimental} CACHE BOOL "1 if the C++ filesystem library is the experimental version")
+
+set(_found FALSE)
+
+if(CXX_FILESYSTEM_HAVE_FS)
+    # We have some filesystem library available. Do link checks
+    string(CONFIGURE [[
+        #include <cstdlib>
+        #include <@CXX_FILESYSTEM_HEADER@>
+
+        int main() {
+            auto cwd = @CXX_FILESYSTEM_NAMESPACE@::current_path();
+            printf("%s", cwd.c_str());
+            return EXIT_SUCCESS;
+        }
+    ]] code @ONLY)
+
+    # Check a simple filesystem program without any linker flags
+    _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
+
+    set(can_link ${CXX_FILESYSTEM_NO_LINK_NEEDED})
+
+    if(NOT CXX_FILESYSTEM_NO_LINK_NEEDED)
+        set(prev_libraries ${CMAKE_REQUIRED_LIBRARIES})
+        # Add the libstdc++ flag
+        set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lstdc++fs)
+        _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_STDCPPFS_NEEDED)
+        set(can_link ${CXX_FILESYSTEM_STDCPPFS_NEEDED})
+        if(NOT CXX_FILESYSTEM_STDCPPFS_NEEDED)
+            # Try the libc++ flag
+            set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lc++fs)
+            _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_CPPFS_NEEDED)
+            set(can_link ${CXX_FILESYSTEM_CPPFS_NEEDED})
+        endif()
+    endif()
+
+    if(can_link)
+        add_library(std::filesystem INTERFACE IMPORTED)
+        set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_17)
+        set(_found TRUE)
+
+        if(CXX_FILESYSTEM_NO_LINK_NEEDED)
+            # Nothing to add...
+        elseif(CXX_FILESYSTEM_STDCPPFS_NEEDED)
+            set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_LINK_LIBRARIES -lstdc++fs)
+        elseif(CXX_FILESYSTEM_CPPFS_NEEDED)
+            set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_LINK_LIBRARIES -lc++fs)
+        endif()
+    endif()
+endif()
+
+cmake_pop_check_state()
+
+set(Filesystem_FOUND ${_found} CACHE BOOL "TRUE if we can run a program using std::filesystem" FORCE)
+
+if(Filesystem_FIND_REQUIRED AND NOT Filesystem_FOUND)
+    message(FATAL_ERROR "Cannot run simple program using std::filesystem")
+endif()

--- a/tools/unitrace/src/levelzero/ze_metrics.h
+++ b/tools/unitrace/src/levelzero/ze_metrics.h
@@ -519,7 +519,7 @@ class ZeMetricProfiler {
         std::map<uint64_t, std::pair<std::string, size_t>> kprops;
         int max_kname_size = 0;
         // enumberate all kernel property files
-        for (const auto& e: std::filesystem::directory_iterator(std::filesystem::path(data_dir_name_))) {
+        for (const auto& e: CXX_FILESYSTEM_NAMESPACE::directory_iterator(CXX_FILESYSTEM_NAMESPACE::path(data_dir_name_))) {
           // kernel properties file path: <data_dir>/.kprops.<device_id>.<pid>.txt
           if (e.path().filename().string().find(".kprops." + std::to_string(it->second->device_id_)) == 0) {
             std::ifstream kpf = std::ifstream(e.path());
@@ -722,7 +722,7 @@ class ZeMetricProfiler {
       else {
         std::vector<ZeKernelInfo> kinfo;
         // enumberate all kernel time files
-        for (const auto& e: std::filesystem::directory_iterator(std::filesystem::path(data_dir_name_))) {
+        for (const auto& e: CXX_FILESYSTEM_NAMESPACE::directory_iterator(CXX_FILESYSTEM_NAMESPACE::path(data_dir_name_))) {
           // kernel properties file path: <data_dir>/.ktime.<device_id>.<pid>.txt
           if (e.path().filename().string().find(".ktime." + std::to_string(it->second->device_id_)) == 0) {
             std::ifstream kf = std::ifstream(e.path());

--- a/tools/unitrace/src/unitrace.cc
+++ b/tools/unitrace/src/unitrace.cc
@@ -6,7 +6,11 @@
 
 #include <array>
 #include <iostream>
+#if CXX_FILESYSTEM_IS_EXPERIMENTAL
+#include <experimental/filesystem>
+#else
 #include <filesystem>
+#endif
 #include <csignal>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -530,8 +534,8 @@ void CleanUp(int sig) {
   if (data_dir == nullptr) {
     return;
   }
-  for (const auto& e: std::filesystem::directory_iterator(std::filesystem::path(data_dir))) {
-    std::filesystem::remove_all(e.path());
+  for (const auto& e: CXX_FILESYSTEM_NAMESPACE::directory_iterator(CXX_FILESYSTEM_NAMESPACE::path(data_dir))) {
+    CXX_FILESYSTEM_NAMESPACE::remove_all(e.path());
   }
   if (remove(data_dir)) {
     std::cerr << "[WARNING] " << data_dir << " is not removed. Please manually remove it." << std::endl;
@@ -688,9 +692,9 @@ int main(int argc, char *argv[]) {
       while (wait(nullptr) > 0);
 
       DisableProfiling();
-      if (std::filesystem::exists(std::filesystem::path(data_dir))) {
-        for (const auto& e: std::filesystem::directory_iterator(std::filesystem::path(data_dir))) {
-          std::filesystem::remove_all(e.path());
+      if (CXX_FILESYSTEM_NAMESPACE::exists(CXX_FILESYSTEM_NAMESPACE::path(data_dir))) {
+        for (const auto& e: CXX_FILESYSTEM_NAMESPACE::directory_iterator(CXX_FILESYSTEM_NAMESPACE::path(data_dir))) {
+          CXX_FILESYSTEM_NAMESPACE::remove_all(e.path());
         }
         if (remove(data_dir)) {
           std::cerr << "[WARNING] " << data_dir << " is not removed. Please manually remove it." << std::endl;
@@ -699,9 +703,9 @@ int main(int argc, char *argv[]) {
     } else {
       std::cerr << "[ERROR] Failed to create child process" << std::endl;
       DisableProfiling();
-      if (std::filesystem::exists(std::filesystem::path(data_dir))) {
-        for (const auto& e: std::filesystem::directory_iterator(std::filesystem::path(data_dir))) {
-          std::filesystem::remove_all(e.path());
+      if (CXX_FILESYSTEM_NAMESPACE::exists(CXX_FILESYSTEM_NAMESPACE::path(data_dir))) {
+        for (const auto& e: CXX_FILESYSTEM_NAMESPACE::directory_iterator(CXX_FILESYSTEM_NAMESPACE::path(data_dir))) {
+          CXX_FILESYSTEM_NAMESPACE::remove_all(e.path());
         }
         if (remove(data_dir)) {
           std::cerr << "[WARNING] " << data_dir << " is not removed. Please manually remove it." << std::endl;


### PR DESCRIPTION
For example, SLES 15 uses gcc 7.5 as the system compiler and C++ standard library. This supports C++17, but does so for std::filesystem via the std::experimental namespace and requires linking an extra library and including a specially named header.

This change imports BSD-licensed community CMake content to make building unitrace smoother on such platforms.