### PR TITLE
[Unitrace] Use L0 core extension to query PCI properties

### DIFF
--- a/tools/unitrace/src/levelzero/ze_metrics.h
+++ b/tools/unitrace/src/levelzero/ze_metrics.h
@@ -11,7 +11,6 @@
 #include <string.h>
 
 #include <level_zero/ze_api.h>
-#include <level_zero/zes_api.h>
 #include <level_zero/zet_api.h>
 #include <level_zero/layers/zel_tracing_api.h>
 #include "ze_loader.h"
@@ -61,8 +60,8 @@ inline void PrintDeviceList() {
     status = ZE_FUNC(zeDeviceGetProperties)(device_list[i], &device_properties);
     PTI_ASSERT(status == ZE_RESULT_SUCCESS);
 
-    zes_pci_properties_t pci_props{ZES_STRUCTURE_TYPE_PCI_PROPERTIES, };
-    status = ZE_FUNC(zesDevicePciGetProperties)(device_list[i], &pci_props);
+    ze_pci_ext_properties_t pci_props{ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES, };
+    status = ZE_FUNC(zeDevicePciGetPropertiesExt)(device_list[i], &pci_props);
     PTI_ASSERT(status == ZE_RESULT_SUCCESS);
 
     std::cout << "Device #" << i << ": [" << std::hex <<


### PR DESCRIPTION
Unitrace uses sysman in legacy mode (zeInit + ZES_ENABLE_SYSMAN), however this is not supported for Xe2 and newer platforms: https://github.com/intel/compute-runtime/blob/releases/25.22/programmers-guide/SYSMAN.md#support-and-limitations hence leading to an abort on Xe2 and newer devices when calling `unitrace --device-list`.

> ./src/levelzero/ze_metrics.h:66: `void PrintDeviceList(): Assertion `status == ZE_RESULT_SUCCESS' failed.

Since Level-Zero 1.3.0 specification, you can use `zeDevicePciGetPropertiesExt` instead of sysman.
As sysman is only used to query PCI information, you can remove its use and switch to the core extension instead.