### PR TITLE
[UNITRACE] Fix CID 723248 invalid iterator dereference in ZeMetricProfiler

### DIFF
--- a/tools/unitrace/src/levelzero/ze_metrics.h
+++ b/tools/unitrace/src/levelzero/ze_metrics.h
@@ -1156,6 +1156,9 @@ class ZeMetricProfiler {
                 }
               }
               value += samples[i];
+              if (kit == kinfo.end()) {
+                break;
+              }
             }
           }
         }


### PR DESCRIPTION
Fix Coverity CID [723248](https://coverity.devtools.intel.com/prod4/reports/defects.htm?projectId=10374&mergeKey=c503a21b87fd8aabdb684dbb3b89f1f9): After advancing the iterator `kit` past the end and breaking from the innermost loop, the middle loop could continue and dereference the invalid iterator on the next iteration.

Add a check after the inner loop to break out of the middle loop when `kit` reaches `kinfo.end()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)