### PR TITLE
[Unitrace] Fix for bug 104. Crash on Windwos.

### DIFF
--- a/tools/unitrace/src/levelzero/ze_event_cache.h
+++ b/tools/unitrace/src/levelzero/ze_event_cache.h
@@ -29,6 +29,12 @@ class ZeEventCache {
   ZeEventCache& operator=(const ZeEventCache& that) = delete;
 
   ~ZeEventCache() {
+#ifdef _WIN32
+    // on Windows, it is very possible that L0 has been unloaded or is being unloaded at this point and L0 calls may fail
+    // so ignore any L0 call.
+    return;
+#endif /* _WIN32 */
+
     bool destroyed = true;
     const std::lock_guard<std::shared_mutex> lock(lock_);
 


### PR DESCRIPTION

### Description
On Windows it is possible that L0 has been unloaded or is being unloaded at the point when Unitrace is trying to destroy some of resources, hence skipping the destroy during teardown.


Fixes # - [issue-104] (https://github.com/intel/pti-gpu/issues/104)

#### Area of the change

- [ ] PTI SDK
- [x] Unitrace
- [ ] Other Tool(s) - _e.g. Sysmon, or any code above SDK directory (except Unitrace)_
- [ ] Infrastructure - _e.g. GitHub workflows, and other whole repo impacted_

### Type(s) of change
_Choose one or multiple, leave empty if none of the other choices apply_

- [x] Bug fix - _change that fixes an issue_
- [ ] New feature - _change that adds functionality_
- [ ] Performance improvement - _change that lowers profiling overhead_
- [ ] Code refactoring or clean up
- [ ] Tests - _change in tests_
- [ ] Samples - _change in samples_
- [ ] Documentation - _documentation update_

### Tests

- [ ] Added - _required for new features and some bug fixes_
- [ ] Not needed

#### Specific HW and OS where to run the test unless generic:
_For example, 2 discrete GPUs, integrated GPU, specific GPU model, PyTorch integration test(s)_

### Checklist

- [ ] Have all tests, except Quarantined, passed locally?
- [ ] Do all newly added source files have a license header?

### Details on API(s) or command line option(s) changes

- [ ] API(s) or command line options not changed
- [ ] New API or command line options added
- [ ] Existing API(s) or command line options changed - _so backward compatibility broken_
- [ ] Unknown

#### If applies - details on the broken backward compatibility
_Indicate what API(s) backward compatibility or option(s) is broken, why it might be OK, or suggest on how to deal with it moving forward_

### Notify the following users
_List users with `@` to send notifications_

### Other information
